### PR TITLE
Allow chaining a method that has args

### DIFF
--- a/lib/fastandand.rb
+++ b/lib/fastandand.rb
@@ -1,5 +1,5 @@
 class NilClass
-  NILAND = lambda { x = Object.new; def x.method_missing(sym); nil end; x }[]
+  NILAND = lambda { x = Object.new; def x.method_missing(*args); nil end; x }[]
   def andand
     NILAND
   end 


### PR DESCRIPTION
Currently, if you try something like:

   label.andand.sub(/Cat/, Dog)

then when label is nil you get a cryptic error:

   ArgumentError: wrong number of arguments (3 for 1)
